### PR TITLE
Update descriptions to escape markdown formatting

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -1,7 +1,7 @@
 title: "Adjust BuildNumber"
 summary: Adjust the $BITRISE_BUILD_NUMBER
 description: |-
-  In some cases you want to use the $BITRISE_BUILD_NUMBER for setting version info, but for some reason
+  In some cases you want to use the `$BITRISE_BUILD_NUMBER` for setting version info, but for some reason
   you want to add, substract or just change the variable (for example when migrating from another build system
   and you already have a certain build number to start with)
 website: https://github.com/stefandevo/bitrise-buildnumberadjust-step
@@ -19,21 +19,21 @@ inputs:
     opts:
       title: "Change Build Number"
       description: |
-        Just change the $BITRISE_BUILD_NUMBER value
+        Just change the `$BITRISE_BUILD_NUMBER` value
       is_expand: true
       is_required: false
   - increase: 
     opts:
       title: "Increase Value"
       description: |
-        Add a certain number to the current $BITRISE_BUILD_NUMBER value
+        Add a certain number to the current `$BITRISE_BUILD_NUMBER` value
       is_expand: true
       is_required: false
   - decrease: 
     opts:
       title: "Decrease Value"
       description: |
-        Substract a certain number of to the current $BITRISE_BUILD_NUMBER value
+        Substract a certain number of to the current `$BITRISE_BUILD_NUMBER` value
       is_expand: true
       is_required: false
 outputs:


### PR DESCRIPTION
![screen shot 2019-02-05 at 1 12 56 pm](https://user-images.githubusercontent.com/1653961/52304799-5f9cb380-2948-11e9-8de9-874b3c37d7fc.png)

I noticed that the description gets formatted using markdown and the environment variable names aren't escaped, so they render as $BITRISE _BUILD_ NUMBER instead of `$BITRISE_BUILD_NUMBER`. This might actually be a problem with Bitrise's Markdown implementation, because the markdown parser here on GitHub is fine with $BITRISE_BUILD_NUMBER and doesn't try to italicize _BUILD_.

In any case, I thought this would be a quick fix, assuming backticks are okay in the yml description fields!